### PR TITLE
Suggestions for `som_pam()` reference SpatRaster

### DIFF
--- a/R/som_pam.r
+++ b/R/som_pam.r
@@ -89,15 +89,19 @@ som_pam <- function(ref.rast, kohsom, k, metric = "manhattan", stand = FALSE,
                            ...
                           )
 
+  # find incomplete cells across all layers
+  idx <- stats::complete.cases(terra::values(ref.rast))
+
+  # make template raster from first layer
+  r.som <- terra::rast(ref.rast[[1]])
+  r.sompam <- r.som
+
   # Rasterize SOM
-  r.som <- ref.rast
-  idx <- stats::complete.cases(terra::values(r.som))
   r.som[idx] <- kohsom$unit.classif
   base::names(r.som) <- "SOM"
   terra::varnames(r.som) <- "SOM"
 
   # Rasterize SOM-based PAM
-  r.sompam <- ref.rast
   r.sompam[idx] <- m.sompam$clustering[kohsom$unit.classif]
   base::names(r.sompam) <- "SOMPAM"
   terra::varnames(r.sompam) <- "SOMPAM"


### PR DESCRIPTION
Hey Brian! Great presentation today, really got me excited about the potential for this package. 
I noticed something with `som_pam()` when I tried to apply to my own data.

The `som_pam()` example shows passing a single layer as the reference raster. It would be convenient if multilayer rasters of input data could be safely passed to create a template and calculate the completeness index for storing the SOM/PAM results.

When `ref.rast` has multiple SpatRaster layers, `som_pam()` fails with `Error: [names<-] incorrect number of names`. Also if additional layers beyond the first have a different pattern of `NA`, the number of TRUE values in the index and the length of `kohsom$unit.classif` may not match.

``` r
library(rassta)
library(terra)
#> terra 1.5.26

dem <- rast(system.file("exdat", "height.tif", package = "rassta"))

# calculate DEM derivatives using terra (NA around margins)
dem$slope <- terrain(dem)
dem$tri <- terrain(dem[[1]], 'TRI')

tsom <- som_gap(var.rast = scale(dem), 
                xdim = 9, ydim = 9, rlen = 150,
                mode = "online", K.max = 6, B = 300, 
                spaceH0 = "original",
                method = "globalSEmax")
                
tpam <- som_pam(ref.rast = dem,
                kohsom = tsom$SOM,
                k = tsom$Kopt)
#> Error: [names<-] incorrect number of names

plot(c(dem, tpam$sompam.rast))
```

I have two suggestions for your consideration:
1) calculate completeness index using all layers if the input has more than one rather than just `ref.rast[[1]]`
2) call `rast(ref.rast[[1]])` to create _empty_ template with same attributes but no values; this prevents values from the source raster showing up in SOM/PAM output for cells with incomplete data

## After this PR:

``` r
library(rassta)
library(terra)
#> terra 1.5.26

dem <- rast(system.file("exdat", "height.tif", package = "rassta"))

# calculate DEM derivatives using terra (NA around margins)
dem$slope <- terrain(dem)
dem$tri <- terrain(dem[[1]], 'TRI')

tsom <- som_gap(var.rast = scale(dem), 
                xdim = 9, ydim = 9, rlen = 150,
                mode = "online", K.max = 6, B = 300, 
                spaceH0 = "original",
                method = "globalSEmax")

tpam <- som_pam(ref.rast = dem,
                kohsom = tsom$SOM,
                k = tsom$Kopt)

plot(c(dem, tpam$sompam.rast))
```

![](https://i.imgur.com/xGcL7nQ.png)

